### PR TITLE
Relax click version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 
 dependencies = [
-    'click==7.1.2',
+    'click>=7.1.2, <9',
     'click-log==0.3.2',
     'botocore>=1.17.47',
     'boto3>=1.14.47',


### PR DESCRIPTION
We want to use an updated version of the click library to deal with a security alert we are seeing in our app. This PR relaxes the version constraint of click to be `>=7.1.2,<9` so that those who need to stay on version 7.x can but we can upgrade to 8.*